### PR TITLE
Update okfnpad links

### DIFF
--- a/specification.md
+++ b/specification.md
@@ -7,7 +7,7 @@
     <http://scholarlyhtml.org/core-specification/>
 
     The document is community-edited here:
-    <http://okfnpad.org/schtml-core> using asciidoc conventions,
+    <http://pad.okfn.org/p/schtml-core> using asciidoc conventions,
     documented here: <http://powerman.name/doc/asciidoc>
 
     ## Requirements


### PR DESCRIPTION
The URL structure of okfnpad links changed and no redirect exists.
